### PR TITLE
Rolling record

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ I only tested this on Arch Linux (which I use, btw!)
 - WIP: Adding the option to toggle game audio + mic audio (Current state: You can enable mic audio, but not disable game audio. Figure out a way to filter and remove audio from pipewiresrc?)
 - WIP: Figuring out why sometimes recording stutter/audio + video don't align. Might require re-transcoding with ffmpeg to re-align dts-stuff? Dunno (Current state: FFmpeg will now copy the files from tmpfs to the ~/Videos-folder and fix dts while doing so. Not working: FFmpeg needs to run AFTER gst-launcher-1.0 finished, but because gst-launcher-1.0 is running through a python subprocess with shell=true this is apparently not that easy and I can not just wait for it?!)
 - WIP: Finishing RTSP-Server-Sink (Current state: UI is done, I should have all libraries? I think? And if not I can easily add missing libraries. But... What is the actual pipeline that I need?)
-- Exploring the possibility of setting up a background process for recording to a tmpfs, and adding a button to properly save the last 30 seconds
 
 ### Thanks
 - [@Newbytee](https://github.com/Newbytee) for pointing out that I forgot the "-e"-option in the gst-launch-1.0-command

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,4 +2,8 @@ FROM ghcr.io/steamdeckhomebrew/holo-base:latest
  
 RUN mkdir /pacman && pacman -Sydd --noconfirm --root /pacman --dbpath /var/lib/pacman gstreamer-vaapi gst-plugin-pipewire gst-plugins-bad-libs gst-plugins-good
 
+RUN pacman -Sydd --noconfirm --dbpath /var/lib/pacman python-pip
+
+RUN pip3 install psutil --target=/psutil
+
 ENTRYPOINT [ "/backend/entrypoint.sh" ]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -6,3 +6,5 @@ OUTDIR="/backend/out"
 cd /backend
 
 cp -r /pacman/usr/lib/* /backend/out
+
+cp -r /psutil /backend/out/

--- a/main.py
+++ b/main.py
@@ -94,7 +94,7 @@ class Plugin:
             # If mode is localFile
             if self._mode == "localFile":
                 logger.info("Local File Recording")
-                dateTime = datetime.now().strftime("%d-%m-%Y_%H-%M-%S")
+                dateTime = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
                 if not self._rolling:
                     logger.info("Setting tmp filepath no rolling")
                     self._tmpFilepath = f"{TMPLOCATION}/Decky-Recorder_{dateTime}.{self._fileformat}"
@@ -276,7 +276,7 @@ class Plugin:
                 for f in reversed(files_to_stitch):
                     ff.write(f"file {str(f)}\n")
 
-            dateTime = datetime.now().strftime("%d-%m-%Y_%H-%M-%S")
+            dateTime = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             ffmpeg = subprocess.Popen(
                 f"ffmpeg -f concat -safe 0 -i {prefix}/files -c copy {self._localFilePath}/Decky-Recorder-{clip_duration}s-{dateTime}.mp4",
                 shell=True,

--- a/main.py
+++ b/main.py
@@ -258,3 +258,4 @@ class Plugin:
             logger.info("finish save rolling function")
         except Exception:
             logger.info(traceback.format_exc())
+        return

--- a/main.py
+++ b/main.py
@@ -293,7 +293,7 @@ class Plugin:
 
             dateTime = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             ffmpeg = subprocess.Popen(
-                f"ffmpeg -f concat -safe 0 -i {prefix}/files -c copy {self._localFilePath}/Decky-Recorder-{clip_duration}s-{dateTime}.{self._fileformat}",
+                f"ffmpeg -f concat -safe 0 -i {this._rollingRecordingFolder}/files -c copy {self._localFilePath}/Decky-Recorder-{clip_duration}s-{dateTime}.{self._fileformat}",
                 shell=True,
                 stdout=std_out_file,
                 stderr=std_err_file,

--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ class Plugin:
 
         # Video Pipeline
         if not is_rolling:
-            ideoPipeline = "pipewiresrc do-timestamp=true ! vaapipostproc ! queue ! vaapih264enc ! h264parse ! mp4mux name=sink !"
+            videoPipeline = "pipewiresrc do-timestamp=true ! vaapipostproc ! queue ! vaapih264enc ! h264parse ! mp4mux name=sink !"
         else:
             videoPipeline = "pipewiresrc do-timestamp=true ! vaapipostproc ! queue ! vaapih264enc ! h264parse !"
             cmd = "{} {}".format(start_command, videoPipeline)

--- a/main.py
+++ b/main.py
@@ -293,7 +293,7 @@ class Plugin:
 
             dateTime = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             ffmpeg = subprocess.Popen(
-                f"ffmpeg -f concat -safe 0 -i {self._rollingRecordingFolder}/files -c copy {self._localFilePath}/Decky-Recorder-{clip_duration}s-{dateTime}.{self._fileformat}",
+                f"ffmpeg -sseof -{clip_duration} -hwaccel vaapi -hwaccel_output_format vaapi -vaapi_device /dev/dri/renderD128 -f concat -safe 0 -i {self._rollingRecordingFolder}/files -c copy {self._localFilePath}/Decky-Recorder-{clip_duration}s-{dateTime}.{self._fileformat}",
                 shell=True,
                 stdout=std_out_file,
                 stderr=std_err_file,

--- a/main.py
+++ b/main.py
@@ -223,7 +223,6 @@ class Plugin:
 
     async def _unload(self):
         logger.info("Unload was called")
-        await Plugin.stop_capturing(self)
         if Plugin.is_capturing(self) == True:
             logger.info("Cleaning up")
             await Plugin.stop_capturing(self)

--- a/main.py
+++ b/main.py
@@ -10,160 +10,191 @@ GSTPLUGINSPATH = DEPSPATH + "/gstreamer-1.0"
 TMPLOCATION = "/tmp"
 
 import logging
-logging.basicConfig(filename="/tmp/decky-recorder.log",
-					format='Decky Recorder: %(asctime)s %(levelname)s %(message)s',
-					filemode='w+',
-					force=True)
+
+logging.basicConfig(
+    filename="/tmp/decky-recorder.log",
+    format="Decky Recorder: %(asctime)s %(levelname)s %(message)s",
+    filemode="w+",
+    force=True,
+)
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
-std_out_file = open('/tmp/decky-recorder-std-out.log', 'w')
-std_err_file = open('/tmp/decky-recorder-std-err.log', 'w')
+std_out_file = open("/tmp/decky-recorder-std-out.log", "w")
+std_err_file = open("/tmp/decky-recorder-std-err.log", "w")
+
+is_rolling = False
+
 
 class Plugin:
 
-	_recording_process = None
+    _recording_process = None
 
-	_tmpFilepath: str = None
-	_filepath: str = None
+    _tmpFilepath: str = None
+    _filepath: str = None
 
-	_mode: str = "localFile"
-	_audioBitrate: int = 128
-	_localFilePath: str = "/home/deck/Videos"
-	_fileformat: str = "mp4"
+    _mode: str = "localFile"
+    _audioBitrate: int = 128
+    _localFilePath: str = "/home/deck/Videos"
+    _fileformat: str = "mp4"
 
-	# Starts the capturing process
-	async def start_capturing(self):
-		logger.info("Starting recording")
-		if Plugin.is_capturing(self) == True:
-			logger.info("Error: Already recording")
-			return
+    # Starts the capturing process
+    async def start_capturing(self):
+        logger.info("Starting recording")
+        if Plugin.is_capturing(self) == True:
+            logger.info("Error: Already recording")
+            return
 
-		os.environ["XDG_RUNTIME_DIR"] = "/run/user/1000"
-		os.environ["XDG_SESSION_TYPE"] = "wayland"
-		os.environ["HOME"] = "/home/deck"
+        os.environ["XDG_RUNTIME_DIR"] = "/run/user/1000"
+        os.environ["XDG_SESSION_TYPE"] = "wayland"
+        os.environ["HOME"] = "/home/deck"
 
-		# Start command including plugin path and ld_lib path
-		start_command = "GST_VAAPI_ALL_DRIVERS=1 GST_PLUGIN_PATH={} LD_LIBRARY_PATH={} gst-launch-1.0 -e -vvv".format(GSTPLUGINSPATH, DEPSPATH)
+        # Start command including plugin path and ld_lib path
+        start_command = "GST_VAAPI_ALL_DRIVERS=1 GST_PLUGIN_PATH={} LD_LIBRARY_PATH={} gst-launch-1.0 -e -vvv".format(
+            GSTPLUGINSPATH, DEPSPATH
+        )
 
-		# Video Pipeline
-		videoPipeline = "pipewiresrc do-timestamp=true ! vaapipostproc ! queue ! vaapih264enc ! h264parse ! mp4mux name=sink !"
-		cmd = "{} {}".format(start_command, videoPipeline)
+        # Video Pipeline
+        if not is_rolling:
+            ideoPipeline = "pipewiresrc do-timestamp=true ! vaapipostproc ! queue ! vaapih264enc ! h264parse ! mp4mux name=sink !"
+        else:
+            videoPipeline = "pipewiresrc do-timestamp=true ! vaapipostproc ! queue ! vaapih264enc ! h264parse !"
+            cmd = "{} {}".format(start_command, videoPipeline)
 
-		# If mode is localFile
-		if (self._mode == "localFile"):
-			logger.info("Local File Recording")
-			dateTime = datetime.now().strftime("%d-%m-%Y_%H-%M-%S")
-			self._tmpFilepath = "{}/Decky-Recorder_{}.mp4".format(TMPLOCATION, dateTime)
-			self._filepath = "{}/Decky-Recorder_{}.{}".format(self._localFilePath, dateTime, self._fileformat)
-			fileSinkPipeline = " filesink location={}".format(self._tmpFilepath)
-			cmd = cmd + fileSinkPipeline
-		else:
-			logger.info("Mode {} does not exist".format(self._mode))
-			return
+        # If mode is localFile
+        if self._mode == "localFile":
+            logger.info("Local File Recording")
+            dateTime = datetime.now().strftime("%d-%m-%Y_%H-%M-%S")
+            if not is_rolling:
+                self._tmpFilepath = "{}/Decky-Recorder_{}.mp4".format(
+                    TMPLOCATION, dateTime
+                )
+            else:
+                self._tmpFilepath = "{}/Decky-Recorder_{}%02d.mp4".format(
+                    TMPLOCATION, dateTime
+                )
+            if not is_rolling:
+                self._filepath = "{}/Decky-Recorder_{}.{}".format(self._localFilePath, dateTime, self._fileformat)
+                fileSinkPipeline = " filesink location={}".format(self._tmpFilepath)
+            else:
+                fileSinkPipeline = " splitmuxsink name=sink muxer=mp4mux muxer-pad-map=x-pad-map,audio=vid location={} max-size-time=1000000000 ".format(
+                    self._tmpFilepath
+                )
+            cmd = cmd + fileSinkPipeline
+        else:
+            logger.info("Mode {} does not exist".format(self._mode))
+            return
 
-		# Creates audio pipeline
-		monitor = subprocess.getoutput("pactl get-default-sink") + ".monitor"
-		cmd = cmd + " pulsesrc device=\"Recording_{}\" ! audioconvert ! lamemp3enc target=bitrate bitrate={} cbr=true ! sink.audio_0".format(monitor, self._audioBitrate)
+        # Creates audio pipeline
+        monitor = subprocess.getoutput("pactl get-default-sink") + ".monitor"
+        cmd = (
+            cmd
+            + ' pulsesrc device="Recording_{}" ! audioconvert ! lamemp3enc target=bitrate bitrate={} cbr=true ! sink.audio_0'.format(
+                monitor, self._audioBitrate
+            )
+        )
 
-		# Starts the capture process
-		logger.info("Command: " + cmd)
-		self._recording_process = subprocess.Popen(cmd, shell = True, stdout = std_out_file, stderr = std_err_file)
-		logger.info("Recording started!")
-		return
+        # Starts the capture process
+        logger.info("Command: " + cmd)
+        self._recording_process = subprocess.Popen(
+            cmd, shell=True, stdout=std_out_file, stderr=std_err_file
+        )
+        logger.info("Recording started!")
+        return
 
-	# Stops the capturing process and cleans up if the mode requires
-	async def stop_capturing(self):
-		logger.info("Stopping recording")
-		if Plugin.is_capturing(self) == False:
-			logger.info("Error: No recording process to stop")
-			return
-		logger.info("Sending sigin")
-		self._recording_process.send_signal(signal.SIGINT)
-		logger.info("Sigin sent. Waiting...")
-		self._recording_process.wait()
-		logger.info("Waiting finished")
-		self._recording_process = None
-		logger.info("Recording stopped!")
+    # Stops the capturing process and cleans up if the mode requires
+    async def stop_capturing(self):
+        logger.info("Stopping recording")
+        if Plugin.is_capturing(self) == False:
+            logger.info("Error: No recording process to stop")
+            return
+        logger.info("Sending sigin")
+        self._recording_process.send_signal(signal.SIGINT)
+        logger.info("Sigin sent. Waiting...")
+        self._recording_process.wait()
+        logger.info("Waiting finished")
+        self._recording_process = None
+        logger.info("Recording stopped!")
 
-		# if recording was a local file
-		if (self._mode == "localFile"):
-			logger.info("Repairing file")
-			ffmpegCmd = "ffmpeg -i {} -c copy {}".format(self._tmpFilepath, self._filepath)
-			logger.info("Command: " + ffmpegCmd)
-			self._tmpFilepath = None
-			self._filepath = None
-			ffmpeg = subprocess.Popen(ffmpegCmd, shell = True, stdout = std_out_file, stderr = std_err_file)
-			ffmpeg.wait()
-			logger.info("File copied with ffmpeg")
-			os.remove(self._tmpFilepath)
-			logger.info("Tmpfile deleted")
-		return
+        if not is_rolling:
+            # if recording was a local file and not rolling
+            if (self._mode == "localFile"):
+                logger.info("Repairing file")
+                ffmpegCmd = "ffmpeg -i {} -c copy {}".format(self._tmpFilepath, self._filepath)
+                logger.info("Command: " + ffmpegCmd)
+                self._tmpFilepath = None
+                self._filepath = None
+                ffmpeg = subprocess.Popen(ffmpegCmd, shell = True, stdout = std_out_file, stderr = std_err_file)
+                ffmpeg.wait()
+                logger.info("File copied with ffmpeg")
+                os.remove(self._tmpFilepath)
+                logger.info("Tmpfile deleted")
+        return
 
-	# Returns true if the plugin is currently capturing
-	async def is_capturing(self):
-		logger.info("Is capturing? " + str(self._recording_process is not None))
-		return self._recording_process is not None
+    # Returns true if the plugin is currently capturing
+    async def is_capturing(self):
+        logger.info("Is capturing? " + str(self._recording_process is not None))
+        return self._recording_process is not None
 
-	# Sets the current mode, supported modes are: localFile
-	async def set_current_mode(self, mode: str):
-		logger.info("New mode: " + mode)
-		self._mode = mode
+    # Sets the current mode, supported modes are: localFile
+    async def set_current_mode(self, mode: str):
+        logger.info("New mode: " + mode)
+        self._mode = mode
 
-	# Gets the current mode
-	async def get_current_mode(self):
-		logger.info("Current mode: " + self._mode)
-		return self._mode
+    # Gets the current mode
+    async def get_current_mode(self):
+        logger.info("Current mode: " + self._mode)
+        return self._mode
 
-	# Sets audio bitrate
-	async def set_audio_bitrate(self, aduioBitrate: int):
-		logger.info("New audio bitrate: " + aduioBitrate)
-		self._audioBitrate = aduioBitrate
+    # Sets audio bitrate
+    async def set_audio_bitrate(self, aduioBitrate: int):
+        logger.info("New audio bitrate: " + aduioBitrate)
+        self._audioBitrate = aduioBitrate
 
-	# Gets the audio bitrate
-	async def get_audio_bitrate(self):
-		logger.info("Current audio bitrate: " + self._audioBitrate)
-		return self._audioBitrate
+    # Gets the audio bitrate
+    async def get_audio_bitrate(self):
+        logger.info("Current audio bitrate: " + self._audioBitrate)
+        return self._audioBitrate
 
-	# Sets local FilePath
-	async def set_local_filepath(self, localFilePath: str):
-		logger.info("New local filepath: " + localFilePath)
-		self._localFilePath = localFilePath
+    # Sets local FilePath
+    async def set_local_filepath(self, localFilePath: str):
+        logger.info("New local filepath: " + localFilePath)
+        self._localFilePath = localFilePath
 
-	# Gets the local FilePath
-	async def get_local_filepath(self):
-		logger.info("Current local filepath: " + self._localFilePath)
-		return self._localFilePath
+    # Gets the local FilePath
+    async def get_local_filepath(self):
+        logger.info("Current local filepath: " + self._localFilePath)
+        return self._localFilePath
 
-	# Sets local file format
-	async def set_local_fileformat(self, fileformat: str):
-		logger.info("New local file format: " + fileformat)
-		self._fileformat = fileformat
+    # Sets local file format
+    async def set_local_fileformat(self, fileformat: str):
+        logger.info("New local file format: " + fileformat)
+        self._fileformat = fileformat
 
-	# Gets the file format
-	async def get_local_fileformat(self):
-		logger.info("Current local file format: " + self._fileformat)
-		return self._fileformat
+    # Gets the file format
+    async def get_local_fileformat(self):
+        logger.info("Current local file format: " + self._fileformat)
+        return self._fileformat
 
-	async def loadConfig(self):
-		logger.info("Loading config")
-		### TODO: IMPLEMENT ###
-		self._mode = "localFile"
-		self._audioBitrate = 128
-		self._localFilePath = "/home/deck/Videos"
-		self._fileformat = "mp4"
-		return
+    async def loadConfig(self):
+        logger.info("Loading config")
+        ### TODO: IMPLEMENT ###
+        self._mode = "localFile"
+        self._audioBitrate = 128
+        self._localFilePath = "/home/deck/Videos"
+        self._fileformat = "mp4"
+        return
 
-	async def saveConfig(self):
-		logger.info("Saving config")
-		### TODO: IMPLEMENT ###
-		return
+    async def saveConfig(self):
+        logger.info("Saving config")
+        ### TODO: IMPLEMENT ###
+        return
 
-	async def _main(self):
-		await Plugin.loadConfig(self)
-		return
+    async def _main(self):
+        await Plugin.loadConfig(self)
+        return
 
-	async def _unload(self):
-		if Plugin.is_capturing(self) == True:
-			await Plugin.end_recording(self)
-		await Plugin.saveConfig(self)
-		return
+    async def _unload(self):
+        if Plugin.is_capturing(self) == True:
+            await Plugin.end_recording(self)
+            await Plugin.saveConfig(self)
+        return

--- a/main.py
+++ b/main.py
@@ -72,7 +72,7 @@ class Plugin:
                     )
                 else:
                     logger.info("Setting tmp filepath")
-                    self._tmpFilepath = "{}/Decky-Recorder-Rolling_%02d.mp4".format(TMPLOCATION)
+                    self._tmpFilepath = "{}/Decky-Recorder-Rolling_%02d.mp4".format("/dev/shm")
                 if not self._rolling:
                     logger.info("Setting local filepath no rolling")
                     self._filepath = "{}/Decky-Recorder_{}.{}".format(self._localFilePath, dateTime, self._fileformat)

--- a/main.py
+++ b/main.py
@@ -286,8 +286,8 @@ class Plugin:
             ffmpeg.wait()
 
             os.remove(prefix + "/files")
-            logger.info("finish save rolling function")
             self._last_clip_time = time.time()
+            logger.info("finish save rolling function")
             return True
         except Exception:
             logger.info(traceback.format_exc())

--- a/main.py
+++ b/main.py
@@ -104,6 +104,7 @@ class Plugin:
             )
             logger.info("Recording started!")
         except Exception:
+            Plugin.stop_capturing(self)
             logger.info(traceback.format_exc())
         return
 
@@ -146,6 +147,7 @@ class Plugin:
         return self._rolling
 
     async def enable_rolling(self):
+        logger.info("Enable rolling was called begin")
         # if capturing, stop that capture, then re-enable with rolling
         was_capturing = False
         if Plugin.is_capturing(self):
@@ -154,11 +156,14 @@ class Plugin:
         self._rolling = True
         if was_capturing:
             Plugin.start_capturing(self)
+        logger.info("Enable rolling was called end")
 
     async def disable_rolling(self):
+        logger.info("Disable rolling was called begin")
         if Plugin.is_capturing(self):
             Plugin.stop_capturing(self)
         self._rolling = False
+        logger.info("Disable rolling was called end")
 
     # Sets the current mode, supported modes are: localFile
     async def set_current_mode(self, mode: str):

--- a/main.py
+++ b/main.py
@@ -260,7 +260,7 @@ class Plugin:
 
             dateTime = datetime.now().strftime("%d-%m-%Y_%H-%M-%S")
             ffmpeg = subprocess.Popen(
-                f"ffmpeg -f concat -safe 0 -i {prefix}/files -c copy {self._localFilePath}/Decky-Recorder-{clip_duration}s-{dateTime}.mp4",
+                f"ffmpeg -f concat -safe 0 -i {prefix}/files {self._localFilePath}/Decky-Recorder-{clip_duration}s-{dateTime}.mp4",
                 shell=True,
                 stdout=std_out_file,
                 stderr=std_err_file,

--- a/main.py
+++ b/main.py
@@ -1,10 +1,10 @@
 import os
 import sys
+import traceback
 import subprocess
 import signal
 import time
 from datetime import datetime
-import traceback
 from pathlib import Path
 
 DEPSPATH = "/home/deck/homebrew/plugins/decky-recorder/bin"
@@ -24,6 +24,12 @@ logger.setLevel(logging.DEBUG)
 std_out_file = open("/tmp/decky-recorder-std-out.log", "w")
 std_err_file = open("/tmp/decky-recorder-std-err.log", "w")
 
+try:
+    import psutil
+    logger.info(psutil.__path__)
+    sys.path.append("/home/deck/homebrew/plugins/decky-recorder/bin/psutil")
+except Exception:
+    logger.info(traceback.format_exc())
 
 class Plugin:
 

--- a/main.py
+++ b/main.py
@@ -222,7 +222,10 @@ class Plugin:
         return
 
     async def _unload(self):
+        logger.info("Unload was called")
+        await Plugin.stop_capturing(self)
         if Plugin.is_capturing(self) == True:
+            logger.info("Cleaning up")
             await Plugin.stop_capturing(self)
             await Plugin.saveConfig(self)
         return
@@ -230,6 +233,7 @@ class Plugin:
     async def save_rolling_recording(self, clip_duration: float = 30.0, prefix="/dev/shm"):
         logger.info("Called save rolling function")
         try:
+            clip_duration = float(clip_duration)
             files = list(Path(prefix).glob("Decky-Recorder-Rolling*"))
             times = [os.path.getmtime(p) for p in files]
             ft = sorted(zip(files, times), key=lambda x: -x[1])
@@ -244,7 +248,8 @@ class Plugin:
 
             dateTime = datetime.now().strftime("%d-%m-%Y_%H-%M-%S")
             ffmpeg = subprocess.Popen(
-                f"ffmpeg -f concat -safe 0 -i {prefix}/files -c copy {self._localFilePath}/Decky-Recorder-{clip_duration}s-{dateTime}.{self._fileformat}",
+                f"ffmpeg -f concat -safe 0 -i {prefix}/files -c copy {self._localFilePath}/Decky-Recorder-{clip_duration}s-{dateTime}.mp4",
+                # f"ffmpeg -hwaccel vaapi -hwaccel_output_format vaapi -vaapi_device /dev/dri/renderD128 -f concat -safe 0 -c copy -i {prefix}/files -codec:v h264_vaapi {self._localFilePath}/Decky-Recorder-{clip_duration}s-{dateTime}.{self._fileformat}",
                 shell=True,
                 stdout=std_out_file,
                 stderr=std_err_file,

--- a/main.py
+++ b/main.py
@@ -293,7 +293,7 @@ class Plugin:
 
             dateTime = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             ffmpeg = subprocess.Popen(
-                f"ffmpeg -f concat -safe 0 -i {this._rollingRecordingFolder}/files -c copy {self._localFilePath}/Decky-Recorder-{clip_duration}s-{dateTime}.{self._fileformat}",
+                f"ffmpeg -f concat -safe 0 -i {self._rollingRecordingFolder}/files -c copy {self._localFilePath}/Decky-Recorder-{clip_duration}s-{dateTime}.{self._fileformat}",
                 shell=True,
                 stdout=std_out_file,
                 stderr=std_err_file,

--- a/main.py
+++ b/main.py
@@ -49,9 +49,12 @@ class Plugin:
     _mode: str = "localFile"
     _audioBitrate: int = 128
     _localFilePath: str = "/home/deck/Videos"
+    _rollingRecordingFolder: str = "/dev/shm"
+    _rollingRecordingPrefix: str = "Decky-Recorder-Rolling"
     _fileformat: str = "mp4"
     _rolling: bool = False
     _last_clip_time: float = time.time()
+    _muxer_map = {"mp4": "mp4mux", "mkv": "matroskamux", "mov": "qtmux"}
 
     async def clear_rogue_gst_processes(self):
         gst_pids = find_gst_processes()
@@ -65,6 +68,8 @@ class Plugin:
     async def start_capturing(self):
         try:
             logger.info("Starting recording")
+            muxer = Plugin._muxer_map.get(self._fileformat, "mp4mux")
+            logger.info(f"Starting recording for {self._fileformat} with mux {muxer}")
             if await Plugin.is_capturing(self) == True:
                 logger.info("Error: Already recording")
                 return

--- a/main.py
+++ b/main.py
@@ -249,7 +249,6 @@ class Plugin:
             dateTime = datetime.now().strftime("%d-%m-%Y_%H-%M-%S")
             ffmpeg = subprocess.Popen(
                 f"ffmpeg -f concat -safe 0 -i {prefix}/files -c copy {self._localFilePath}/Decky-Recorder-{clip_duration}s-{dateTime}.mp4",
-                # f"ffmpeg -hwaccel vaapi -hwaccel_output_format vaapi -vaapi_device /dev/dri/renderD128 -f concat -safe 0 -c copy -i {prefix}/files -codec:v h264_vaapi {self._localFilePath}/Decky-Recorder-{clip_duration}s-{dateTime}.{self._fileformat}",
                 shell=True,
                 stdout=std_out_file,
                 stderr=std_err_file,

--- a/main.py
+++ b/main.py
@@ -287,7 +287,7 @@ class Plugin:
                 if max_time - ftime <= clip_duration:
                     actual_dur = max_time - ftime
                     files_to_stitch.append(f)
-            with open(self._rollingRecordingPrefix + "/files", "w") as ff:
+            with open(self._rollingRecordingFolder + "/files", "w") as ff:
                 for f in reversed(files_to_stitch):
                     ff.write(f"file {str(f)}\n")
 
@@ -299,7 +299,7 @@ class Plugin:
                 stderr=std_err_file,
             )
             ffmpeg.wait()
-            os.remove(prefix + "/files")
+            os.remove(self._rollingRecordingFolder + "/files")
             self._last_clip_time = time.time()
             logger.info("finish save rolling function")
             return int(actual_dur)

--- a/main.py
+++ b/main.py
@@ -53,6 +53,7 @@ class Plugin:
     _localFilePath: str = "/home/deck/Videos"
     _fileformat: str = "mp4"
     _rolling: bool = False
+    _last_clip_time: float = time.time()
 
     async def clear_rogue_gst_processes(self):
         gst_pids = find_gst_processes()
@@ -258,6 +259,9 @@ class Plugin:
 
     async def save_rolling_recording(self, clip_duration: float = 30.0, prefix="/dev/shm"):
         logger.info("Called save rolling function")
+        if time.time() - self._last_clip_time < 5:
+            logger.info("Too early to record another clip")
+            return False
         try:
             clip_duration = float(clip_duration)
             files = list(Path(prefix).glob("Decky-Recorder-Rolling*"))
@@ -283,6 +287,8 @@ class Plugin:
 
             os.remove(prefix + "/files")
             logger.info("finish save rolling function")
+            self._last_clip_time = time.time()
+            return True
         except Exception:
             logger.info(traceback.format_exc())
-        return
+        return False

--- a/main.py
+++ b/main.py
@@ -247,20 +247,11 @@ class Plugin:
         logger.info("Called save rolling function")
         try:
             files = list(Path(prefix).glob("Decky-Recorder-Rolling*"))
-            logger.info(str(files))
             times = [os.path.getmtime(p) for p in files]
-            logger.info(str(times))
             ft = sorted(zip(files, times), key=lambda x: -x[1])
             max_time = ft[0][1] - 1
-            logger.info(str(max_time))
             files_to_stitch = []
             for f, ftime in ft:
-                logger.info(type(max_time))
-                logger.info(type(ftime))
-                logger.info(type(clip_duration))
-                logger.info(ftime)
-                logger.info(clip_duration)
-                logger.info(max_time)
                 if max_time - ftime < clip_duration:
                     files_to_stitch.append(f)
             with open(prefix + "/files", "w") as ff:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 120
+target-version = ['py37']

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -103,6 +103,10 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 		}
 	}
 
+        const rollingRecordButtonPress = async() => {
+            await serverAPI.callPluginMethod('save_rolling_recording', {});
+        }
+
 	const rollingToggled = async () => {
 		if (isRolling === false) {
 			setRolling(true);
@@ -165,7 +169,7 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
                         </PanelSectionRow>
 
                         {(isRolling)
-                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>Save 30 Seconds</ButtonItem></PanelSectionRow> : null }
+                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing} onClick={() => {rollingRecordButtonPress()}}>Save 30 Seconds</ButtonItem></PanelSectionRow> : null }
 
                         {(isRolling)
                         ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>Save 1 minute</ButtonItem></PanelSectionRow> : null }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,7 +49,7 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 		setCapturing(getIsCapturingResponse.result as boolean);
 
 		const getIsRollingResponse = await serverAPI.callPluginMethod('is_rolling', {});
-		setCapturing(getIsRollingResponse.result as boolean);
+		setRolling(getIsRollingResponse.result as boolean);
 
 		const getModeResponse = await serverAPI.callPluginMethod('get_current_mode', {});
 		setMode(getModeResponse.result as string);
@@ -157,12 +157,12 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
                                 />
                         </PanelSectionRow>
 
-                        {/* <PanelSectionRow><ToggleField
+                        <PanelSectionRow><ToggleField
                         label="Do Rolling Recording?"
                         checked={isRolling}
                         onChange={(e)=>{setRolling(e); rollingToggled();}}
                         />
-                        </PanelSectionRow> */}
+                        </PanelSectionRow>
 
                         {(isRolling)
                         ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>Save 30 Seconds</ButtonItem></PanelSectionRow> : null }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -92,7 +92,7 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 
 	}
 
-        const notify(message: string, duration: number = 1000) = async() => {
+        const notify = async(message: string, duration: number = 1000) => {
             await serverAPI.toaster.toast({
             title: message,
             body: message,
@@ -114,7 +114,7 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 
         const rollingRecordButtonPress = async(duration: number) => {
             await serverAPI.callPluginMethod('save_rolling_recording', {clip_duration: duration});
-            notify("Saved " + number + " second recording");
+            await notify("Saved " + number + " second clip");
         }
 
 	const rollingToggled = async () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -116,8 +116,10 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 	}
 
 	const rollingRecordButtonPress = async (duration: number) => {
-		await serverAPI.callPluginMethod('save_rolling_recording', { clip_duration: duration });
-		await notify("Saved " + duration + " second clip");
+		let res = await serverAPI.callPluginMethod('save_rolling_recording', { clip_duration: duration }).result;
+                if (res) {
+                    await notify("Saved " + duration + " second clip");
+                }
 	}
 
 	async function handleButtonInput(val: any[]) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -144,7 +144,7 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 			if (Date.now() - ugly.pressedAt < 2000) {
 				continue;
 			}
-			if (inputs.ulButtons && inputs.ulButtons & (1 << 13) && inputs.ulButtons & (1 << 16)) {
+			if (inputs.ulButtons && inputs.ulButtons & (1 << 13) && inputs.ulButtons & (1 << 4)) {
 				ugly.pressedAt = Date.now();
 				(Router as any).DisableHomeAndQuickAccessButtons();
 				setTimeout(() => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,7 +20,7 @@ import {
 
 import { FaVideo } from "react-icons/fa";
 
-let ugly = {fn: null, pressedAt: Date.now()};
+let ugly = { fn: null, pressedAt: Date.now() };
 
 const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 
@@ -29,6 +29,8 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 	const [mode, setMode] = useState<string>("localFile");
 
 	const [isRolling, setRolling] = useState<boolean>(false);
+
+	const [buttonsEnabled, setButtonsEnabled] = useState<boolean>(true);
 
 	const audioBitrateOption128 = { data: "128", label: "128 Kbps" } as SingleDropdownOption
 	const audioBitrateOption192 = { data: "192", label: "192 Kbps" } as SingleDropdownOption
@@ -116,10 +118,24 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 	}
 
 	const rollingRecordButtonPress = async (duration: number) => {
-		let res = await serverAPI.callPluginMethod('save_rolling_recording', { clip_duration: duration }).result;
-                if (res) {
-                    await notify("Saved " + duration + " second clip");
-                }
+		setButtonsEnabled(false);
+		setTimeout(() => {
+			setButtonsEnabled(true);
+		}, 1000)
+		const res = await serverAPI.callPluginMethod('save_rolling_recording', { clip_duration: duration });
+		if ((res.result as boolean)) {
+			await notify("Saved " + duration + " second clip");
+		}
+	}
+
+	const shouldButtonsBeEnabled = () => {
+		if (!isCapturing) {
+			return false;
+		}
+		if (!buttonsEnabled) {
+			return false;
+		}
+		return true;
 	}
 
 	async function handleButtonInput(val: any[]) {
@@ -150,8 +166,8 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 				ugly.pressedAt = Date.now();
 				(Router as any).DisableHomeAndQuickAccessButtons();
 				setTimeout(() => {
-				(Router as any).EnableHomeAndQuickAccessButtons();
-					}, 1000)
+					(Router as any).EnableHomeAndQuickAccessButtons();
+				}, 1000)
 				await rollingRecordButtonPress(30);
 
 			}
@@ -220,16 +236,16 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 			</PanelSectionRow>
 
 			{(isRolling)
-				? <PanelSectionRow><ButtonItem disabled={!isCapturing} onClick={() => { rollingRecordButtonPress(30) }}>30 sec</ButtonItem></PanelSectionRow> : null}
+				? <PanelSectionRow><ButtonItem disabled={!shouldButtonsBeEnabled()} onClick={() => { rollingRecordButtonPress(30) }}>30 sec</ButtonItem></PanelSectionRow> : null}
 
 			{(isRolling)
-				? <PanelSectionRow><ButtonItem disabled={!isCapturing} onClick={() => { rollingRecordButtonPress(60) }}>1 min</ButtonItem></PanelSectionRow> : null}
+				? <PanelSectionRow><ButtonItem disabled={!shouldButtonsBeEnabled()} onClick={() => { rollingRecordButtonPress(60) }}>1 min</ButtonItem></PanelSectionRow> : null}
 
 			{(isRolling)
-				? <PanelSectionRow><ButtonItem disabled={!isCapturing} onClick={() => { rollingRecordButtonPress(60 * 2) }}>2 min</ButtonItem></PanelSectionRow> : null}
+				? <PanelSectionRow><ButtonItem disabled={!shouldButtonsBeEnabled()} onClick={() => { rollingRecordButtonPress(60 * 2) }}>2 min</ButtonItem></PanelSectionRow> : null}
 
 			{(isRolling)
-				? <PanelSectionRow><ButtonItem disabled={!isCapturing} onClick={() => { rollingRecordButtonPress(60 * 5) }}>5 min</ButtonItem></PanelSectionRow> : null}
+				? <PanelSectionRow><ButtonItem disabled={!shouldButtonsBeEnabled()} onClick={() => { rollingRecordButtonPress(60 * 5) }}>5 min</ButtonItem></PanelSectionRow> : null}
 
 		</PanelSection>
 	);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -96,7 +96,7 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 		if (isCapturing === false){
 			setCapturing(true);
 			await serverAPI.callPluginMethod('start_capturing', {});
-			// Router.CloseSideMenus();
+			Router.CloseSideMenus();
 		} else {
 			setCapturing(false);
 			await serverAPI.callPluginMethod('stop_capturing', {});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -238,6 +238,7 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI, logic: DeckyRecorderLogic }> = 
 					checked={isRolling}
 					onChange={(e) => { setRolling(e); rollingToggled(); }}
 				/>
+				<div>Steam + Y saves a 30 second clip in replay mode. If replay mode is off, this shortcut will enable it.</div>
 				{(!isRolling) ?
 					<ButtonItem
 						label={getLabelText()}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -137,15 +137,20 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
                 <PanelSection>
 
                         <PanelSectionRow>
-                                <ButtonItem
-                                        label={getLabelText()}
-                                        bottomSeparator="none"
-                                        layout="below"
-                                        onClick={() => {
-                                                recordingButtonPress();
-                                        }}>
-                                        {getRecordingButtonText()}
-                                </ButtonItem>
+                            <ToggleField
+                            label="Replay Mode"
+                            checked={isRolling}
+                            onChange={(e)=>{setRolling(e); rollingToggled();}}
+                            />
+                            <ButtonItem
+                                    label={getLabelText()}
+                                    bottomSeparator="none"
+                                    layout="below"
+                                    onClick={() => {
+                                            recordingButtonPress();
+                                    }}>
+                                    {getRecordingButtonText()}
+                            </ButtonItem>
                         </PanelSectionRow>
 
                         <PanelSectionRow>
@@ -161,24 +166,17 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
                                 />
                         </PanelSectionRow>
 
-                        <PanelSectionRow><ToggleField
-                        label="Do Rolling Recording?"
-                        checked={isRolling}
-                        onChange={(e)=>{setRolling(e); rollingToggled();}}
-                        />
-                        </PanelSectionRow>
+                        {(isRolling)
+                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing} onClick={() => {rollingRecordButtonPress()}}>30 sec</ButtonItem></PanelSectionRow> : null }
 
                         {(isRolling)
-                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing} onClick={() => {rollingRecordButtonPress()}}>Save 30 Seconds</ButtonItem></PanelSectionRow> : null }
+                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>1 min</ButtonItem></PanelSectionRow> : null }
 
                         {(isRolling)
-                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>Save 1 minute</ButtonItem></PanelSectionRow> : null }
+                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>2 min</ButtonItem></PanelSectionRow> : null }
 
                         {(isRolling)
-                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>Save 2 minutes</ButtonItem></PanelSectionRow> : null }
-
-                        {(isRolling)
-                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>Save 5 minutes</ButtonItem></PanelSectionRow> : null }
+                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>5 min</ButtonItem></PanelSectionRow> : null }
 
                 </PanelSection>
         );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -173,7 +173,12 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 				setTimeout(() => {
 					(Router as any).EnableHomeAndQuickAccessButtons();
 				}, 1000)
-				await rollingRecordButtonPress(30);
+				if (isRolling) {
+					await rollingRecordButtonPress(30);
+				} else {
+					setRolling(true);
+					rollingToggled();
+				}
 
 			}
 		}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,8 @@ import {
 	Dropdown,
 	DropdownOption,
 	SingleDropdownOption,
-	Router
+	Router,
+        ToggleField
 } from "decky-frontend-lib";
 
 import {
@@ -24,6 +25,8 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 	const [isCapturing, setCapturing] = useState<boolean>(false);
 
 	const [mode, setMode] = useState<string>("localFile");
+
+	const [isRolling, setRolling] = useState<boolean>(false);
 
 	const audioBitrateOption128 = {data: "128", label: "128 Kbps"} as SingleDropdownOption
 	const audioBitrateOption192 = {data: "192", label: "192 Kbps"} as SingleDropdownOption
@@ -101,7 +104,7 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 		return "Recordings will be saved to " + localFilePath;
 	}
 
-	const getButtonText = (): string => {
+	const getRecordingButtonText = (): string => {
 		if (isCapturing === false){
 			return "Start Recording";
 		} else {
@@ -113,35 +116,56 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 		initState();
 	}, []);
 
-	return (
-		<PanelSection>
-			<PanelSectionRow>
-				<ButtonItem
-					label={getLabelText()}
-					bottomSeparator="none"
-					layout="below"
-					onClick={() => {
-						recordingButtonPress();
-					}}>
-					{getButtonText()}
-				</ButtonItem>
-			</PanelSectionRow>
+        return (
+                <PanelSection>
 
-			<PanelSectionRow>
-				<Dropdown
-					menuLabel="Select the video file format"
-					strDefaultLabel={localFileFormat.label as string}
-					rgOptions={formatOptions}
-					selectedOption={localFileFormat}
-					onChange={(newLocalFileFormat) => {
-						serverAPI.callPluginMethod('set_local_fileformat', {fileformat: newLocalFileFormat.data});
-						setLocalFileFormat(newLocalFileFormat);
-					}}
-				/>
-			</PanelSectionRow>
+                        <PanelSectionRow>
+                                <ButtonItem
+                                        label={getLabelText()}
+                                        bottomSeparator="none"
+                                        layout="below"
+                                        onClick={() => {
+                                                recordingButtonPress();
+                                        }}>
+                                        {getRecordingButtonText()}
+                                </ButtonItem>
+                        </PanelSectionRow>
 
-		</PanelSection>
-	);
+                        <PanelSectionRow>
+                                <Dropdown
+                                        menuLabel="Select the video file format"
+                                        strDefaultLabel={localFileFormat.label as string}
+                                        rgOptions={formatOptions}
+                                        selectedOption={localFileFormat}
+                                        onChange={(newLocalFileFormat) => {
+                                                serverAPI.callPluginMethod('set_local_fileformat', {fileformat: newLocalFileFormat.data});
+                                                setLocalFileFormat(newLocalFileFormat);
+                                        }}
+                                />
+                        </PanelSectionRow>
+
+                        <PanelSectionRow><ToggleField
+                        label="Do Rolling Recording?"
+                        checked={isRolling}
+                        onChange={(e)=>setRolling(e)}
+                        />
+                        </PanelSectionRow>
+
+                        {(isRolling)
+                        ? <PanelSectionRow><ButtonItem disabled={!this.isCapturing}>Save 30 Seconds</ButtonItem></PanelSectionRow> : null }
+
+                        {(isRolling)
+                        ? <PanelSectionRow><ButtonItem disabled={!this.isCapturing}>Save 1 minute</ButtonItem></PanelSectionRow> : null }
+
+                        {(isRolling)
+                        ? <PanelSectionRow><ButtonItem disabled={!this.isCapturing}>Save 2 minutes</ButtonItem></PanelSectionRow> : null }
+
+                        {(isRolling)
+                        ? <PanelSectionRow><ButtonItem disabled={!this.isCapturing}>Save 5 minutes</ButtonItem></PanelSectionRow> : null }
+
+                </PanelSection>
+        );
+
 };
 
 export default definePlugin((serverApi: ServerAPI) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -96,7 +96,7 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 		if (isCapturing === false){
 			setCapturing(true);
 			await serverAPI.callPluginMethod('start_capturing', {});
-			Router.CloseSideMenus();
+			// Router.CloseSideMenus();
 		} else {
 			setCapturing(false);
 			await serverAPI.callPluginMethod('stop_capturing', {});
@@ -157,12 +157,12 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
                                 />
                         </PanelSectionRow>
 
-                        <PanelSectionRow><ToggleField
+                        {/* <PanelSectionRow><ToggleField
                         label="Do Rolling Recording?"
                         checked={isRolling}
                         onChange={(e)=>{setRolling(e); rollingToggled();}}
                         />
-                        </PanelSectionRow>
+                        </PanelSectionRow> */}
 
                         {(isRolling)
                         ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>Save 30 Seconds</ButtonItem></PanelSectionRow> : null }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,6 +48,9 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 		const getIsCapturingResponse = await serverAPI.callPluginMethod('is_capturing', {});
 		setCapturing(getIsCapturingResponse.result as boolean);
 
+		const getIsRollingResponse = await serverAPI.callPluginMethod('is_rolling', {});
+		setCapturing(getIsRollingResponse.result as boolean);
+
 		const getModeResponse = await serverAPI.callPluginMethod('get_current_mode', {});
 		setMode(getModeResponse.result as string);
 
@@ -100,6 +103,16 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 		}
 	}
 
+	const rollingToggled = async () => {
+		if (isRolling === false) {
+			setRolling(true);
+			await serverAPI.callPluginMethod('enable_rolling', {});
+		} else {
+			setRolling(false);
+			await serverAPI.callPluginMethod('disable_rolling', {});
+		}
+	}
+
 	const getLabelText = (): string => {
 		return "Recordings will be saved to " + localFilePath;
 	}
@@ -147,21 +160,21 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
                         <PanelSectionRow><ToggleField
                         label="Do Rolling Recording?"
                         checked={isRolling}
-                        onChange={(e)=>setRolling(e)}
+                        onChange={(e)=>{setRolling(e); rollingToggled();}}
                         />
                         </PanelSectionRow>
 
                         {(isRolling)
-                        ? <PanelSectionRow><ButtonItem disabled={!this.isCapturing}>Save 30 Seconds</ButtonItem></PanelSectionRow> : null }
+                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>Save 30 Seconds</ButtonItem></PanelSectionRow> : null }
 
                         {(isRolling)
-                        ? <PanelSectionRow><ButtonItem disabled={!this.isCapturing}>Save 1 minute</ButtonItem></PanelSectionRow> : null }
+                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>Save 1 minute</ButtonItem></PanelSectionRow> : null }
 
                         {(isRolling)
-                        ? <PanelSectionRow><ButtonItem disabled={!this.isCapturing}>Save 2 minutes</ButtonItem></PanelSectionRow> : null }
+                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>Save 2 minutes</ButtonItem></PanelSectionRow> : null }
 
                         {(isRolling)
-                        ? <PanelSectionRow><ButtonItem disabled={!this.isCapturing}>Save 5 minutes</ButtonItem></PanelSectionRow> : null }
+                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>Save 5 minutes</ButtonItem></PanelSectionRow> : null }
 
                 </PanelSection>
         );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,7 +55,6 @@ class DeckyRecorderLogic
 
 	toggleRolling = async (isRolling: boolean) => {
 		if (!isRolling) {
-			await this.notify("Enabling replay mode", 1500, "Steam + Y to save last 30 seconds");
 			await this.serverAPI.callPluginMethod('enable_rolling', {});
 		} else {
 			await this.serverAPI.callPluginMethod('disable_rolling', {});
@@ -96,6 +95,7 @@ class DeckyRecorderLogic
 				if (isRolling.result as boolean) {
 					await this.saveRollingRecording(30);
 				} else {
+					await this.notify("Enabling replay mode", 1500, "Steam + Y to save last 30 seconds");
 					this.toggleRolling(false);
 				}
 			}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -92,18 +92,18 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 
 	}
 
-        const notify = async(message: string, duration: number = 1000) => {
+        const notify = async(message: string, duration: number=1000) => {
             await serverAPI.toaster.toast({
             title: message,
             body: message,
             duration: duration,
             critical: true
             });
-            setCapturing(true);
         }
 
 	const recordingButtonPress = async() => {
 		if (isCapturing === false){
+                        setCapturing(true);
 			await serverAPI.callPluginMethod('start_capturing', {});
 			Router.CloseSideMenus();
                 } else {
@@ -114,7 +114,7 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 
         const rollingRecordButtonPress = async(duration: number) => {
             await serverAPI.callPluginMethod('save_rolling_recording', {clip_duration: duration});
-            await notify("Saved " + number + " second clip");
+            await notify("Saved " + duration + " second clip");
         }
 
 	const rollingToggled = async () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -207,6 +207,16 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI, logic: DeckyRecorderLogic }> = 
 		return true;
 	}
 
+	const disableFileformatDropdown = () => {
+		if (isCapturing) {
+			return true;
+		}
+		if (isRolling) {
+			return true;
+		}
+		return false;
+	}
+
 	const rollingToggled = async () => {
 		logic.toggleRolling(isRolling);
 		setCapturing(!isRolling);
@@ -255,6 +265,7 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI, logic: DeckyRecorderLogic }> = 
 			<PanelSectionRow>
 				<Dropdown
 					menuLabel="Select the video file format"
+					disabled={disableFileformatDropdown()}
 					strDefaultLabel={localFileFormat.label as string}
 					rgOptions={formatOptions}
 					selectedOption={localFileFormat}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -92,12 +92,21 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 
 	}
 
+        const notify(message: string, duration: number = 1000) = async() => {
+            await serverAPI.toaster.toast({
+            title: message,
+            body: message,
+            duration: duration,
+            critical: true
+            });
+            setCapturing(true);
+        }
+
 	const recordingButtonPress = async() => {
 		if (isCapturing === false){
-			setCapturing(true);
 			await serverAPI.callPluginMethod('start_capturing', {});
 			Router.CloseSideMenus();
-		} else {
+                } else {
 			setCapturing(false);
 			await serverAPI.callPluginMethod('stop_capturing', {});
 		}
@@ -105,6 +114,7 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 
         const rollingRecordButtonPress = async(duration: number) => {
             await serverAPI.callPluginMethod('save_rolling_recording', {clip_duration: duration});
+            notify("Saved " + number + " second recording");
         }
 
 	const rollingToggled = async () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -104,7 +104,7 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 	}
 
         const rollingRecordButtonPress = async(duration: number) => {
-            await serverAPI.callPluginMethod('save_rolling_recording', {});
+            await serverAPI.callPluginMethod('save_rolling_recording', {clip_duration: duration});
         }
 
 	const rollingToggled = async () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -103,7 +103,7 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 		}
 	}
 
-        const rollingRecordButtonPress = async() => {
+        const rollingRecordButtonPress = async(duration: number) => {
             await serverAPI.callPluginMethod('save_rolling_recording', {});
         }
 
@@ -167,16 +167,16 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
                         </PanelSectionRow>
 
                         {(isRolling)
-                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing} onClick={() => {rollingRecordButtonPress()}}>30 sec</ButtonItem></PanelSectionRow> : null }
+                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing} onClick={() => {rollingRecordButtonPress(30)}}>30 sec</ButtonItem></PanelSectionRow> : null }
 
                         {(isRolling)
-                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>1 min</ButtonItem></PanelSectionRow> : null }
+                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing} onClick={() => {rollingRecordButtonPress(60)}}>1 min</ButtonItem></PanelSectionRow> : null }
 
                         {(isRolling)
-                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>2 min</ButtonItem></PanelSectionRow> : null }
+                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing} onClick={() => {rollingRecordButtonPress(60*2)}}>2 min</ButtonItem></PanelSectionRow> : null }
 
                         {(isRolling)
-                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing}>5 min</ButtonItem></PanelSectionRow> : null }
+                        ? <PanelSectionRow><ButtonItem disabled={!isCapturing} onClick={() => {rollingRecordButtonPress(60*5)}}>5 min</ButtonItem></PanelSectionRow> : null }
 
                 </PanelSection>
         );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,7 +29,10 @@ class DeckyRecorderLogic
 		this.serverAPI = serverAPI;
 	}
 
-	notify = async (message: string, duration: number = 1000) => {
+	notify = async (message: string, duration: number = 1000, body: string = "") => {
+		if (!body) {
+			body = message;
+		}
 		await this.serverAPI.toaster.toast({
 			title: message,
 			body: message,
@@ -52,7 +55,7 @@ class DeckyRecorderLogic
 
 	toggleRolling = async (isRolling: boolean) => {
 		if (!isRolling) {
-			await this.notify("Enabling replay mode, Steam + Y to save last 30 seconds", 1000);
+			await this.notify("Enabling replay mode", 1500, "Steam + Y to save last 30 seconds");
 			await this.serverAPI.callPluginMethod('enable_rolling', {});
 		} else {
 			await this.serverAPI.callPluginMethod('disable_rolling', {});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,7 +35,7 @@ class DeckyRecorderLogic
 		}
 		await this.serverAPI.toaster.toast({
 			title: message,
-			body: message,
+			body: body,
 			duration: duration,
 			critical: true
 		});
@@ -92,7 +92,7 @@ class DeckyRecorderLogic
 				setTimeout(() => {
 					(Router as any).EnableHomeAndQuickAccessButtons();
 				}, 1000)
-				let isRolling = await this.serverAPI.callPluginMethod("is_rolling", {});
+				const isRolling = await this.serverAPI.callPluginMethod("is_rolling", {});
 				if (isRolling.result as boolean) {
 					await this.saveRollingRecording(30);
 				} else {
@@ -209,9 +209,8 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI, logic: DeckyRecorderLogic }> = 
 
 	const rollingToggled = async () => {
 		logic.toggleRolling(isRolling);
+		setCapturing(!isRolling);
 		setRolling(!isRolling);
-		let res = await serverAPI.callPluginMethod('is_capturing', {});
-		setCapturing(res.result as boolean);
 	}
 
 	const getLabelText = (): string => {


### PR DESCRIPTION
This isn't finished yet. It's working but some of the plumbing needs a bit more work and I'd like to integrate notifications. Opening it as a draft PR for visibility and discussion.

How it works:
I'm keeping rolling 2 second clips for the last 5 minutes in `/dev/shm` which is essentially tmpfs. Upon request I use `ffmpeg concat` to stitch the right length of clip together.

What's left:

- [x] Add Toast notifications for clip save
- [x] Add a shortcut for saving 30 second clip (and possibly for starting/stopping recording)
- [x] Add a clean up step at the start of recording (or possibly as a background thread) that gets rid of any dangling gst-launch processes. This can happen during reloads.
- [x] Add feedback for capturing a clip by disabling buttons when the request is underway and showing a notification when the clip is done saving
