### PR TITLE
Alphabetical and chronological ordering on timestamps and filenames

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ class Plugin:
 		# If mode is localFile
 		if (self._mode == "localFile"):
 			logger.info("Local File Recording")
-			dateTime = datetime.now().strftime("%d-%m-%Y_%H-%M-%S")
+			dateTime = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 			self._tmpFilepath = "{}/Decky-Recorder_{}.mp4".format(TMPLOCATION, dateTime)
 			self._filepath = "{}/Decky-Recorder_{}.{}".format(self._localFilePath, dateTime, self._fileformat)
 			fileSinkPipeline = " filesink location={}".format(self._tmpFilepath)


### PR DESCRIPTION
## What this change does

There's a timestamp used in output filenames like in the following:
`self._filepath = "{}/Decky-Recorder_{}.{}".format(self._localFilePath, dateTime, self._fileformat)`

In this PR, I modify the datetime string from 
`day-month-year`
to
`year-month-day`


`03-11-2023_01-09-07`
to
`2023-03-11_01-09-07`


## Why

- This makes a file lists alphabetical sort equivalent to its chronological sort
- This makes the stored video files sort better in file browsers
- day and month have leading zeroes

## Extra
https://en.wikipedia.org/wiki/ISO_8601?useskin=vector#General_principles
https://strftime.net/