### PR TITLE
Don't do ffmpeg -c

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ std_err_file = open("/tmp/decky-recorder-std-err.log", "w")
 try:
     sys.path.append("/home/deck/homebrew/plugins/decky-recorder/bin/psutil")
     import psutil
+
     logger.info("Successfully loaded psutil")
 except Exception:
     logger.info(traceback.format_exc())
@@ -42,10 +43,7 @@ def find_gst_processes():
 
 class Plugin:
     _recording_process = None
-
-    _tmpFilepath: str = None
     _filepath: str = None
-
     _mode: str = "localFile"
     _audioBitrate: int = 128
     _localFilePath: str = "/home/deck/Videos"
@@ -99,19 +97,18 @@ class Plugin:
             if self._mode == "localFile":
                 logger.info("Local File Recording")
                 dateTime = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-                if not self._rolling:
-                    logger.info("Setting tmp filepath no rolling")
-                    self._tmpFilepath = f"{TMPLOCATION}/Decky-Recorder_{dateTime}.{self._fileformat}"
-                else:
+                if self._rolling:
                     logger.info("Setting tmp filepath")
-                    self._tmpFilepath = f"{self._rollingRecordingFolder}/{self._rollingRecordingPrefix}_%02d.{self._fileformat}"
+                    self._filepath = (
+                        f"{self._rollingRecordingFolder}/{self._rollingRecordingPrefix}_%02d.{self._fileformat}"
+                    )
                 if not self._rolling:
                     logger.info("Setting local filepath no rolling")
                     self._filepath = f"{self._localFilePath}/Decky-Recorder_{dateTime}.{self._fileformat}"
-                    fileSinkPipeline = f" filesink location={self._tmpFilepath} "
+                    fileSinkPipeline = f" filesink location={self._filepath} "
                 else:
                     logger.info("Setting local filepath")
-                    fileSinkPipeline = f" splitmuxsink name=sink muxer={muxer} muxer-pad-map=x-pad-map,audio=vid location={self._tmpFilepath} max-size-time=2000000000 max-files=240"
+                    fileSinkPipeline = f" splitmuxsink name=sink muxer={muxer} muxer-pad-map=x-pad-map,audio=vid location={self._filepath} max-size-time=2000000000 max-files=240"
                 cmd = cmd + fileSinkPipeline
             else:
                 logger.info(f"Mode {self._mode} does not exist")
@@ -153,22 +150,6 @@ class Plugin:
         self._recording_process = None
         logger.info("Recording stopped!")
 
-        if not self._rolling:
-            # if recording was a local file and not rolling
-            if self._mode == "localFile":
-                logger.info("Repairing file")
-                ffmpegCmd = f"ffmpeg -i {self._tmpFilepath} -c copy {self._filepath}"
-                logger.info("Command: " + ffmpegCmd)
-                ffmpeg = subprocess.Popen(ffmpegCmd, shell=True, stdout=std_out_file, stderr=std_err_file)
-                ffmpeg.wait()
-                logger.info("File copied with ffmpeg")
-                try:
-                    os.remove(self._tmpFilepath)
-                    logger.info("Tmpfile deleted")
-                except Exception:
-                    logger.error("Could not delete tmp file" + traceback.format_exc())
-                self._tmpFilepath = None
-                self._filepath = None
         return
 
     # Returns true if the plugin is currently capturing

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -127,7 +127,7 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI, logic: DeckyRecorderLogic }> = 
 	const formatOptionMp4 = { data: "mp4", label: "MP4" } as SingleDropdownOption
 	const formatOptionMkv = { data: "mkv", label: "Matroska (.mkv)" } as SingleDropdownOption;
 	const formatOptionMov = { data: "mov", label: "QuickTime (.mov)" } as SingleDropdownOption;
-	const formatOptions: DropdownOption[] = [formatOptionMp4, formatOptionMkv, formatOptionMov];
+	const formatOptions: DropdownOption[] = [formatOptionMkv, formatOptionMp4, formatOptionMov];
 	const [localFileFormat, setLocalFileFormat] = useState<DropdownOption>(formatOptionMp4);
 
 	const initState = async () => {


### PR DESCRIPTION
I wanted to see if things would work correctly if instead of saving to a tmpfile and then doing ffmpeg -c we just saved directly to the Videos folder. Best as I can tell the videos are saved correctly for all 3 formats. I also re-ordered the formats to have MKV be at the top, because it's the only format that can survive gstreamer getting sigkill-ed (or the deck rebooting during recording).

This should hopefully lead to less data loss.