### PR TITLE
Implement AAC audio encoding using FAAC

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/steamdeckhomebrew/holo-base:latest
  
-RUN mkdir /pacman && pacman -Sydd --noconfirm --root /pacman --dbpath /var/lib/pacman gstreamer-vaapi gst-plugin-pipewire gst-plugins-bad-libs gst-plugins-good
+RUN mkdir /pacman && pacman -Sydd --noconfirm --root /pacman --dbpath /var/lib/pacman gstreamer-vaapi gst-plugin-pipewire gst-plugins-bad gst-plugins-bad-libs gst-plugins-good faac
 
 RUN pacman -Sydd --noconfirm --dbpath /var/lib/pacman python-pip
 

--- a/main.py
+++ b/main.py
@@ -56,7 +56,7 @@ class Plugin:
     _recording_process = None
     _filepath: str = None
     _mode: str = "localFile"
-    _audioBitrate: int = 128
+    _audioBitrate: int = 192000
     _localFilePath: str = decky_plugin.HOME + "/Videos"
     _rollingRecordingFolder: str = "/dev/shm"
     _rollingRecordingPrefix: str = "Decky-Recorder-Rolling"
@@ -156,7 +156,7 @@ class Plugin:
                     break
             cmd = (
                 cmd
-                + f' pulsesrc device="Recording_{monitor}" ! audio/x-raw, channels=2 ! audioconvert ! lamemp3enc target=bitrate bitrate={self._audioBitrate} cbr=true ! sink.audio_0'
+                + f' pulsesrc device="Recording_{monitor}" ! audio/x-raw, channels=2 ! audioconvert ! faac bitrate={self._audioBitrate} rate-control=2 ! sink.audio_0'
             )
 
             # Starts the capture process
@@ -271,7 +271,7 @@ class Plugin:
         self._settings = SettingsManager(name="decky-loader-settings", settings_directory=settingsDir)
         self._settings.read()
         self._mode = "localFile"
-        self._audioBitrate = 128
+        self._audioBitrate = 192000
 
         self._localFilePath = self._settings.getSetting("output_folder", "/home/deck/Videos")
         self._fileformat = self._settings.getSetting("format", "mp4")


### PR DESCRIPTION
This PR changes the audio encoding from MP3 to AAC, which should hopefully improve audio quality and compatibility, especially with Apple devices (fixing #21).

I'm currently using the `faac` plugin for GStreamer, which involves pulling in the `gst-plugins-bad` package, which isn't ideal considering the amount of extra plugins being added that will be going unused, but I'm not sure if there's much I can do to cut down on file sizes there (although overall space used still seems fine to me).

Compared to the other AAC encoders for GStreamer, I found FAAC to be the easiest to get working and didn't have any issues, so I just went with that. One thing to be aware of is that its bitrate option uses bits intsead of kilobits, which I've adjusted for in `main.py`.

I also increased the bitrate to 192 kbps from 128, which should improve audio quality further and helps combat generational loss from YouTube, Twitter and other services re-encoding the audio. 160 would probably also be fine, ultimately this change doesn't really matter too much so feel free to set it to whatever you're most happy with.

In my limited testing things still seem to perform the same as before, although I'd probably recommend double checking things yourself just to make sure.

Sample recording (excuse my poor gamplay lol): https://safe.derpychap.co.uk/eoSbVvNP.mp4